### PR TITLE
Allow to provide data and clock pin for I2C bus

### DIFF
--- a/LCD03.cpp
+++ b/LCD03.cpp
@@ -25,18 +25,18 @@
 
 char _i2c_address;
 
-LCD03::LCD03() {
-  // Convert 8-bit address from LCD to 7-bit address for Wire
-  _i2c_address = I2C_ADDR>>1;
-}
-
 LCD03::LCD03(char i2c_address) {
   // Convert 8-bit address from LCD to 7-bit address for Wire
   _i2c_address = i2c_address>>1;
 }
 
-void LCD03::begin(uint8_t cols, uint8_t rows) {
-  Wire.begin();
+LCD03::LCD03(char i2c_address) {
+    // Convert 8-bit address from LCD to 7-bit address for Wire
+    _i2c_address = i2c_address>>1;
+}
+
+void LCD03::begin(uint8_t cols, uint8_t rows, uint8_t sda_pin=SDA, uint8_t scl_pin) {
+  Wire.begin(sda_pin, scl_pin);
   noCursor();
   clear();
 }

--- a/LCD03.h
+++ b/LCD03.h
@@ -74,11 +74,10 @@
 class LCD03 : public Print {
 public:
   // Constructors
-  LCD03();
-  LCD03(char);
+  LCD03(char i2c_address=I2C_ADDR);
   
   // LiquidCrystal compatible functions  
-  void begin(uint8_t, uint8_t);
+  void begin(uint8_t cols, uint8_t rows, uint8_t sda_pin=SDA, uint8_t scl_pin=SCL);
   void clear();
   void home();
   void setCursor(uint8_t);

--- a/README.md
+++ b/README.md
@@ -27,22 +27,20 @@ You'll need to restart the Arduino IDE after installing before the library will 
 
 The following public functions are exposed.
 
-### LCD03()
+### LCD03([i2c_address])
 
-New LCD03 at the default I2C address (0xC6).
-
-### LCD03(i2c_address)
-
-New LCD03 at `i2c_address`.
+New LCD03 at `i2c_address`. The parameter is optional and defaults to LCD03's default I2C address (0xC6).
 
 *i2c_address (char): 8-bit I2C address of the display (as displayed during initilisation)*
 
-### begin(cols, rows)
+### begin(cols, rows, [i2c_sda][, i2c_scl])
 
 Initialise the display of size `cols` * `rows`, clear the display and set the cursor to the top-left.
 
 *cols (uint8_t): the number of display columns*  
 *rows (uint8_t): the number of display rows*
+*i2c_sda (uint8_t): the data pin for the i2c connection (optinal, defaults to setting SDA from Wire.h)
+*i2c_scl (uint8_t): the clock pin for the i2c connection (optinal, defaults to setting SCL from Wire.h)
 
 ### clear()
 


### PR DESCRIPTION
To use the lib in ESP8266 devices I added parameters to to provide data and clock pin for I2C bus in the begin method.